### PR TITLE
Use delete[] to destroy m_pad

### DIFF
--- a/panonymizer.cpp
+++ b/panonymizer.cpp
@@ -34,7 +34,7 @@ PAnonymizer::PAnonymizer(const char* ciphername, const u_int8_t * key) :
 
 //Destructor
 PAnonymizer::~PAnonymizer() {
-    delete m_pad;
+    delete[] m_pad;
 }
 
 //Anonymization funtion


### PR DESCRIPTION
m_pad is an array and the delete[] operator should be used instead of delete.